### PR TITLE
reqs registry key improvements

### DIFF
--- a/R/aaa-registry_instances.R
+++ b/R/aaa-registry_instances.R
@@ -1,7 +1,11 @@
 # we need memoising out here because we want to cache values across different
 # instances of the class
 reqs_registry_filename <- memoise::memoise(function(reqs) {
-  digest::digest(lapply(reqs, `[`, c("name", "version", "source")))
+  # sort reqs before computing digest to make sure
+  # we don't get a different registry key just because we
+  # change the order of its entries
+  pkg_names <- vapply(reqs, `[[`, character(1), "names")
+  digest::digest(lapply(reqs[order(pkg_names)], `[`, c("name", "version", "source")))
 })
 
 REQS_REGISTRY <- ObjectRegistry$new(

--- a/R/aaa-registry_instances.R
+++ b/R/aaa-registry_instances.R
@@ -1,7 +1,7 @@
 # we need memoising out here because we want to cache values across different
 # instances of the class
 reqs_registry_filename <- memoise::memoise(function(reqs) {
-  digest::digest(lapply(reqs, `[`, c("name", "version")))
+  digest::digest(lapply(reqs, `[`, c("name", "version", "source")))
 })
 
 REQS_REGISTRY <- ObjectRegistry$new(
@@ -16,7 +16,7 @@ LOCKFILE_REGISTRY <- ObjectRegistry$new(
   read_fn     = read_list,
   write_fn    = write_list,
   filename_fn = function(lockfile) {
-    lockfile$installation_order <- lapply(lockfile$installation_order, `[`, c("name", "version"))
+    lockfile$installation_order <- lapply(lockfile$installation_order, `[`, c("name", "version", "source"))
     digest::digest(lockfile[c("reqs_registry_key", "installation_order")])
   }
 )

--- a/R/generate_lockfile.R
+++ b/R/generate_lockfile.R
@@ -1,5 +1,5 @@
 generate_lockfile <- function(reqs) {
-  validate_reqs(reqs)
+  reqs     <- validate_reqs(reqs)
   dep_tree <- DependencyTree$new(reqs)
   lockfile <- list(
     requirements       = dep_tree$reqs(),
@@ -15,11 +15,16 @@ generate_lockfile <- function(reqs) {
 }
 
 validate_reqs <- function(reqs) {
-  lapply(reqs, function(x) {
-    if (!all(c("name", "version") %in% names(x))) {
+  lapply(reqs, function(required_pkg) {
+    if (!all(c("name", "version") %in% names(required_pkg))) {
       stop("Your requirements list has an entry that's missing ",
            "either a 'name' or a 'version', but these are needed ",
            "to generate a lockfile. Please fix this.")
     }
+    if (!"source" %in% names(required_pkg)) {
+      # the default source for a package is CRAN
+      required_pkg$source <- "CRAN"
+    }
+    required_pkg
   })
 }


### PR DESCRIPTION
* use `source` in generation of registry keys (so that a CRAN version of a package vs a github version of a package don't get treated as the same entry)
* sort reqs before generating a registry key, to avoid double-registering a reqs file just because the order of entries changed.